### PR TITLE
fix: Clean install npm deps to fix rollup bug on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
     runtime: static
     name: ulster-elections
     rootDir: frontend
-    buildCommand: npm install && npm run build
+    buildCommand: rm -rf node_modules package-lock.json && npm install && npm run build
     staticPublishPath: dist
     routes:
       - type: rewrite


### PR DESCRIPTION
Fixes the npm dependency build issue on Render deployment by ensuring clean install of dependencies.